### PR TITLE
Chore - Use Scala 2.13 built-in resource management

### DIFF
--- a/src/main/scala/com/hhandoko/aktiform/app/view/render/Component.scala
+++ b/src/main/scala/com/hhandoko/aktiform/app/view/render/Component.scala
@@ -1,10 +1,9 @@
 package com.hhandoko.aktiform.app.view.render
 
 import scala.io.Source
+import scala.util.Using
 
 import com.samskivert.mustache.{Mustache, Template}
-
-import com.hhandoko.aktiform.core.helper.AutoCloseableResource.using
 
 /** Basic (abstract) trait to define renderable component.
   *
@@ -30,7 +29,7 @@ sealed trait Component {
   def templatePath: String
 
   protected lazy val templateSource: String =
-    using(Source.fromResource(templatePath))(_.mkString)
+    Using.resource(Source.fromResource(templatePath))(_.mkString)
 
   protected lazy val template: Template =
     Mustache

--- a/src/main/scala/com/hhandoko/aktiform/app/view/render/DynamicPageRender.scala
+++ b/src/main/scala/com/hhandoko/aktiform/app/view/render/DynamicPageRender.scala
@@ -2,6 +2,7 @@ package com.hhandoko.aktiform.app.view.render
 
 import java.util.{Collections, HashMap => JHashMap}
 import scala.io.Source
+import scala.util.Using
 
 import com.samskivert.mustache.Mustache
 import com.samskivert.mustache.Mustache.TemplateLoader
@@ -9,7 +10,6 @@ import com.typesafe.scalalogging.LazyLogging
 
 import com.hhandoko.aktiform.api.html.{Element, Page}
 import com.hhandoko.aktiform.app.config.resource.ResourceVariant
-import com.hhandoko.aktiform.core.helper.AutoCloseableResource.using
 
 /** Page renderer using dynamic master template.
   *
@@ -37,7 +37,7 @@ final class DynamicPageRender(
     val loader: TemplateLoader = (name: String) => {
       Source.fromResource(section(name)).reader()
     }
-    val raw = using(Source.fromResource(master))(_.mkString)
+    val raw = Using.resource(Source.fromResource(master))(_.mkString)
     val context =
       new JHashMap[String, AnyRef] {
         this.put("meta", Collections.EMPTY_MAP)


### PR DESCRIPTION
## Summary

Replace `using` with Scala 2.13 built-in `Using.resource`.

<hr>

## Pull Request (PR) Checklist

### Documentation
- [x] Update documentation in `README.md`

### Code Review
- [x] Self code review -- take another pass through the changes yourself
- [x] Completed all relevant `TODO`s, or call them out in the PR comments or raise a separate chore

### Tests
- [x] All tests passes
